### PR TITLE
Remove wrong string validation from Changelog

### DIFF
--- a/Assets/PatchKit/UnityEditorExtension/Editor/Core/AppVersionChangelog.cs
+++ b/Assets/PatchKit/UnityEditorExtension/Editor/Core/AppVersionChangelog.cs
@@ -32,18 +32,6 @@ public struct AppVersionChangelog
             return "Application version changelog cannot be null.";
         }
 
-        if (!value.All(
-            c => char.IsLetterOrDigit(c) ||
-                char.IsWhiteSpace(c) ||
-                c == ':' ||
-                c == '_' ||
-                c == '-'))
-        {
-            return
-                "The label text can include only letters,\n" +
-                "numbers, and ':', '_', or '-' characters.";
-        }
-
         return null;
     }
 }


### PR DESCRIPTION
Changelog is getting validated with the same validations as Label string, this forces the dev to not include a changelog or follow a similar string validation rule as the Label string at the changelog body to be able to send the **Build & Upload**.

![image](https://github.com/patchkit-net/patchkit-unity-editor-extension/assets/19819051/be249e73-9ac7-4c31-b14c-4338946c6b32)
![image](https://github.com/patchkit-net/patchkit-unity-editor-extension/assets/19819051/fc1a2e54-20c1-4840-8ead-ec7caac68a80)
![image](https://github.com/patchkit-net/patchkit-unity-editor-extension/assets/19819051/3c191a9f-185b-4474-8c06-daa159bef76f)
